### PR TITLE
Use slim instead of onbuild for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM node:6.10.2-onbuild
+FROM node:6.10.2-slim
 
 # Install Redis
-RUN apt-get update && apt-get -y install redis-server
+RUN apt-get update && apt-get -y install redis-server --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
 
 # Create app directory
 RUN mkdir -p /usr/src/humix
@@ -9,7 +10,7 @@ WORKDIR /usr/src/humix
 
 # Bundle app source
 COPY . /usr/src/humix
-RUN npm install
+RUN npm_config_loglevel=silent npm install
 
 RUN mkdir /data && chown redis:redis /data
 VOLUME /data


### PR DESCRIPTION
slim variant is smaller then onbuild and it's more proper for
the device like raspberry. Also remove unnecessary files while
building the image.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>